### PR TITLE
#6 - don't run if the browser natively supports HLS streaming

### DIFF
--- a/lib/vjs-hls.js
+++ b/lib/vjs-hls.js
@@ -113,4 +113,6 @@ var attachVideojsStreamrootProvider = function (window, videojs) {
     videojs.StreamrootProviderHLS = StreamrootProviderHLS;
 };
 
-attachVideojsStreamrootProvider(window, window.videojs);
+if (!document.createElement('video').canPlayType('application/vnd.apple.mpegURL')) {
+    attachVideojsStreamrootProvider(window, window.videojs);
+}


### PR DESCRIPTION
Conditional to not run if browser has native support (https://github.com/streamroot/videojs-hls.js/issues/6)
