### PR TITLE
Check if mediaError is null.

### DIFF
--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -12,23 +12,25 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         _video.addEventListener('error', function(evt) {
             var errorTxt,mediaError=evt.currentTarget.error;
 
-            switch(mediaError.code) {
-                case mediaError.MEDIA_ERR_ABORTED:
-                    errorTxt = "You aborted the video playback";
-                    break;
-                case mediaError.MEDIA_ERR_DECODE:
-                    errorTxt = "The video playback was aborted due to a corruption problem or because the video used features your browser did not support";
-                    _handleMediaError();
-                    break;
-                case mediaError.MEDIA_ERR_NETWORK:
-                    errorTxt = "A network error caused the video download to fail part-way";
-                    break;
-                case mediaError.MEDIA_ERR_SRC_NOT_SUPPORTED:
-                    errorTxt = "The video could not be loaded, either because the server or network failed or because the format is not supported";
-                    break;
-            }
+            if (mediaError !== null) {
+                switch(mediaError.code) {
+                    case mediaError.MEDIA_ERR_ABORTED:
+                        errorTxt = "You aborted the video playback";
+                        break;
+                    case mediaError.MEDIA_ERR_DECODE:
+                        errorTxt = "The video playback was aborted due to a corruption problem or because the video used features your browser did not support";
+                        _handleMediaError();
+                        break;
+                    case mediaError.MEDIA_ERR_NETWORK:
+                        errorTxt = "A network error caused the video download to fail part-way";
+                        break;
+                    case mediaError.MEDIA_ERR_SRC_NOT_SUPPORTED:
+                        errorTxt = "The video could not be loaded, either because the server or network failed or because the format is not supported";
+                        break;
+                }
 
-            console.error("MEDIA_ERROR: ", errorTxt);
+                console.error("MEDIA_ERROR: ", errorTxt);
+            }
         });
 
         function initialize() {


### PR DESCRIPTION
Fixes `TypeError: mediaError is null` in Firefox console.
