### PR TITLE
Fixes v5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Video.js >=5.0.0 < 5.3.0 compatibility (missing `getTech` method).
 
 ## [0.3.0] - 2018-04-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Include video.js and videojs-hlsjs-plugin.js in your page:
 
 ```html
 <head>
-    <link href="http://vjs.zencdn.net/5.0/video-js.min.css" rel="stylesheet">
-    <script src="http://vjs.zencdn.net/5.0/video.min.js"></script>
+    <link href="http://vjs.zencdn.net/6.6.3/video-js.css" rel="stylesheet">
+    <script src="http://vjs.zencdn.net/6.6.3/video.js"></script>
+
     <script src="videojs-hlsjs-plugin.js"></script>
 </head>
 

--- a/example/index.html
+++ b/example/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
 
     <!-- video.js -->
-    <link href="../node_modules/video.js/dist/video-js.css" rel="stylesheet">
-    <script src="../node_modules/video.js/dist/video.js"></script>
+    <link href="http://vjs.zencdn.net/6.6.3/video-js.css" rel="stylesheet">
+    <script src="http://vjs.zencdn.net/6.6.3/video.js"></script>
 
     <script src="../dist/videojs-hlsjs-plugin.js"></script>
 </head>

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -212,7 +212,25 @@ var registerSourceHandler = function (videojs) {
     };
 
     if (Hlsjs.isSupported()) {
-        videojs.getTech('Html5').registerSourceHandler({
+        var html5;
+
+        if (typeof videojs.getTech === 'function') {
+            html5 = videojs.getTech('Html5');
+        } else if (typeof videojs.getComponent === 'function') {
+            html5 = videojs.getComponent('Html5');
+        } else {
+            console.error('Not supported version if video.js');
+
+            return;
+        }
+
+        if (!html5) {
+            console.error('Not supported version if video.js');
+
+            return;
+        }
+
+        html5.registerSourceHandler({
             canHandleSource: function (source) {
                 var hlsTypeRE = /^application\/x-mpegURL$/i;
                 var hlsExtRE = /\.m3u8/i;

--- a/package.json
+++ b/package.json
@@ -19,12 +19,10 @@
     "test:lint": "eslint lib/"
   },
   "dependencies": {
-    "hls.js": "^0.8.9",
-    "lodash.defaults": "4.2.0",
-    "url-parse": "1.2.0"
+    "hls.js": "^0.8.9"
   },
   "devDependencies": {
-    "ajv": "^6.4.0",
+    "ajv": "6.4.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-preset-es2015": "6.24.1",
@@ -33,7 +31,6 @@
     "eslint-config-airbnb-base": "12.1.0",
     "eslint-plugin-import": "2.8.0",
     "uglify-js": "2.6.0",
-    "video.js": "^5.20.5",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.11.2"
   }


### PR DESCRIPTION
1. Updates urls to video.js 
1. Removes not used dependencies.
1. Fixes video.js >=5.0.0 < 5.3.0 compatibility once and for all.
1. Puts an error message if used with not supported version of video.js.