### PR TITLE
Add mechanism to pass hlsjsConfig through VJS plugin config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Dev]
 
 ## [Unreleased]
+### Added
+- Allow Hls.js config to be passed through VideoJS plugin config. (For Brightcove where we don't pass options directly)
 
 ## [0.3.1] - 2018-04-05
 ### Fixed

--- a/example/index-plugin.html
+++ b/example/index-plugin.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+
+    <!-- video.js -->
+    <link href="http://vjs.zencdn.net/6.6.3/video-js.css" rel="stylesheet">
+    <script src="http://vjs.zencdn.net/6.6.3/video.js"></script>
+
+    <script src="../dist/videojs-hlsjs-plugin.js"></script>
+</head>
+<body>
+    <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls autoplay muted>
+        <source src="http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8" type="application/x-mpegURL"/>
+    </video>
+
+    <script>
+        var options = {
+            plugins: {
+              // JSON config added by Brightcove player generator
+              streamrootHls: {
+                hlsjsConfig: {
+                  // Your Hls.js config
+                  debug: true,
+                },
+              }
+            }
+        };
+        var player = videojs('example-video', options);
+    </script>
+</body>
+</html>

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,8 @@
-var registerSourceHandler = require('./videojs-hlsjs-plugin.js');
+var vjsPlugin = require('./videojs-hlsjs-plugin.js');
 
 if (window.videojs) {
-    registerSourceHandler(window.videojs);
+    vjsPlugin.registerConfigPlugin(window.videojs);
+    vjsPlugin.registerSourceHandler(window.videojs);
 }
 
-module.exports = { register: registerSourceHandler };
+module.exports = { register: vjsPlugin.registerSourceHandler };

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -123,7 +123,9 @@ var registerSourceHandler = function (videojs) {
         }
 
         function _initHlsjs() {
-            var hlsjsConfig = tech.options_.hlsjsConfig || {};
+            var hlsjsConfigRef = tech.options_.hlsjsConfig;
+            // NOTE: Hls.js will write to the reference thus change the object for later streams
+            var hlsjsConfig = hlsjsConfigRef ? JSON.parse(JSON.stringify(hlsjsConfigRef)) : {};
 
             if (['', 'auto'].indexOf(_video.preload) === -1 && !_video.autoplay && hlsjsConfig.autoStartLoad === undefined) {
                 hlsjsConfig.autoStartLoad = false;
@@ -263,4 +265,29 @@ var registerSourceHandler = function (videojs) {
     videojs.Html5Hlsjs = Html5Hlsjs;
 };
 
-module.exports = registerSourceHandler;
+function streamrootHlsjsConfigHandler(options) {
+    var player = this;
+
+    if (!options) {
+        return;
+    }
+
+    if (!player.options_.html5) {
+        player.options_.html5 = {};
+    }
+
+    if (!player.options_.html5.hlsjsConfig) {
+        player.options_.html5.hlsjsConfig = options.hlsjsConfig;
+    }
+}
+
+var registerConfigPlugin = function (videojs) {
+    // Used in Brightcove since we don't pass options directly there
+    var registerVjsPlugin = videojs.registerPlugin || videojs.plugin;
+    registerVjsPlugin('streamrootHls', streamrootHlsjsConfigHandler);
+};
+
+module.exports = {
+    registerSourceHandler: registerSourceHandler,
+    registerConfigPlugin: registerConfigPlugin
+};


### PR DESCRIPTION
Some use cases are video-js over a player editor that don't allow us to pass `options` directly but through plugin config instead. This PR adds:
- A small `streamrootHls` plugin to transfer `hlsjsConfig` to the usual `html5.hlsjsConfig`.
- Clone `hlsjsConfig` before use since Hls.js will put all confs to the passed reference.