### PR TITLE
Properly handle HLS with multiple audio streams and subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Dev]
 
 ## [Unreleased]
+### Added
+- Handle multiple audio switching.
+
+### Fixed
+- Subtitles working but is impossible to turn off or switching.
 
 ## [0.3.3] - 2018-05-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle multiple audio switching.
 
+### Changed
+- Delay emitting `loadedqualitydata` until the video starts playing.
+
 ### Fixed
 - Subtitles working but is impossible to turn off or switching.
+- Video quality data is reported before handlers is registered in `videojs-quality-picker`.
 
 ## [0.3.3] - 2018-05-29
 ### Added

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -82,43 +82,45 @@ var registerSourceHandler = function (videojs) {
             _hls.nextLevel = qualityId;
         }
 
+        function _levelLabel(level) {
+            if (level.height) return level.height + 'p';
+            else if (level.width) return Math.round(level.width * 9 / 16) + 'p';
+            else if (level.bitrate) return (level.bitrate / 1000) + 'kbps';
+            return 0;
+        }
+
         function _notifyVideoQualities() {
-            function _levelLabel(level) {
-                if (level.height) return level.height + 'p';
-                else if (level.width) return Math.round(level.width * 9 / 16) + 'p';
-                else if (level.bitrate) return (level.bitrate / 1000) + 'kbps';
-                return 0;
-            }
+            if (_metadata) {
+                var cleanTracklist = [];
 
-            var cleanTracklist = [];
+                if (_metadata.levels.length > 1) {
+                    var autoLevel = {
+                        id: -1,
+                        label: 'auto',
+                        selected: _hls.manualLevel === -1
+                    };
+                    cleanTracklist.push(autoLevel);
+                }
 
-            if (_metadata.levels.length > 1) {
-                var autoLevel = {
-                    id: -1,
-                    label: 'auto',
-                    selected: _hls.manualLevel === -1
+                _metadata.levels.forEach(function (level, index) {
+                    var quality = {}; // Don't write in level (shared reference with Hls.js)
+                    quality.id = index;
+                    quality.selected = index === _hls.manualLevel;
+                    quality.label = _levelLabel(level);
+
+                    cleanTracklist.push(quality);
+                });
+
+                var payload = {
+                    qualityData: { video: cleanTracklist },
+                    qualitySwitchCallback: switchQuality
                 };
-                cleanTracklist.push(autoLevel);
+
+                tech.trigger('loadedqualitydata', payload);
+
+                // Self-de-register so we don't raise the payload multiple times
+                _video.removeEventListener('play', _notifyVideoQualities);
             }
-
-            _metadata.levels.forEach(function (level, index) {
-                var quality = {}; // Don't write in level (shared reference with Hls.js)
-                quality.id = index;
-                quality.selected = index === _hls.manualLevel;
-                quality.label = _levelLabel(level);
-
-                cleanTracklist.push(quality);
-            });
-
-            var payload = {
-                qualityData: { video: cleanTracklist },
-                qualitySwitchCallback: switchQuality
-            };
-
-            tech.trigger('loadedqualitydata', payload);
-
-            // Self-de-register so we don't raise the payload multiple times
-            _video.removeEventListener('play', _notifyVideoQualities);
         }
 
         function _updateHlsjsAudioTrack() {

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -10,6 +10,7 @@ var registerSourceHandler = function (videojs) {
         var _hls;
         var _errorCounts = {};
         var _duration = null;
+        var _metadata = null;
         var _player = videojs(tech.options_.playerId);
 
         function _executeHooksFor(type) {
@@ -81,7 +82,7 @@ var registerSourceHandler = function (videojs) {
             _hls.nextLevel = qualityId;
         }
 
-        function _onMetaData(event, data) {
+        function _notifyVideoQualities() {
             function _levelLabel(level) {
                 if (level.height) return level.height + 'p';
                 else if (level.width) return Math.round(level.width * 9 / 16) + 'p';
@@ -91,7 +92,7 @@ var registerSourceHandler = function (videojs) {
 
             var cleanTracklist = [];
 
-            if (data.levels.length > 1) {
+            if (_metadata.levels.length > 1) {
                 var autoLevel = {
                     id: -1,
                     label: 'auto',
@@ -100,7 +101,7 @@ var registerSourceHandler = function (videojs) {
                 cleanTracklist.push(autoLevel);
             }
 
-            data.levels.forEach(function (level, index) {
+            _metadata.levels.forEach(function (level, index) {
                 var quality = {}; // Don't write in level (shared reference with Hls.js)
                 quality.id = index;
                 quality.selected = index === _hls.manualLevel;
@@ -115,6 +116,9 @@ var registerSourceHandler = function (videojs) {
             };
 
             tech.trigger('loadedqualitydata', payload);
+
+            // Self-de-register so we don't raise the payload multiple times
+            _video.removeEventListener('play', _notifyVideoQualities);
         }
 
         function _updateHlsjsAudioTrack() {
@@ -213,6 +217,11 @@ var registerSourceHandler = function (videojs) {
             }
         }
 
+        function _onMetaData(event, data) {
+            // This could arrive before 'loadedqualitydata' handlers is registered, remember it so we can raise it later
+            _metadata = data;
+        }
+
         function _initHlsjs() {
             var hlsjsConfigRef = tech.options_.hlsjsConfig;
             // NOTE: Hls.js will write to the reference thus change the object for later streams
@@ -230,13 +239,16 @@ var registerSourceHandler = function (videojs) {
             // For some reason running this after generating text track list will raise an error inside Hls.js (too early perhaps)
             _video.addEventListener('play', _updateHlsjsTextTrack);
 
+            // _notifyVideoQualities sometimes runs before the quality picker event handler is registered -> no video switcher
+            _video.addEventListener('play', _notifyVideoQualities);
+
             _hls = new Hlsjs(hlsjsConfig);
 
             _executeHooksFor('beforeinitialize');
 
             _hls.on(Hlsjs.Events.ERROR, function (event, data) { _onError(event, data, tech, _errorCounts); });
-            _hls.on(Hlsjs.Events.MANIFEST_PARSED, _onMetaData);
             _hls.on(Hlsjs.Events.AUDIO_TRACK_LOADED, _onAudioTracks);
+            _hls.on(Hlsjs.Events.MANIFEST_PARSED, _onMetaData);
             _hls.on(Hlsjs.Events.LEVEL_LOADED, function (event, data) { _duration = data.details.live ? Infinity : data.details.totalduration; });
 
             // Handle text tracks
@@ -258,6 +270,7 @@ var registerSourceHandler = function (videojs) {
         this.dispose = function () {
             _video.removeEventListener('play', _startLoad);
             _video.removeEventListener('play', _updateHlsjsTextTrack);
+            _video.removeEventListener('play', _notifyVideoQualities);
 
             _player.textTracks().removeEventListener('change', _updateHlsjsTextTrack);
             _player.audioTracks().removeEventListener('change', _updateHlsjsAudioTrack);

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -166,8 +166,13 @@ var registerSourceHandler = function (videojs) {
             var hlsjsTracks = _video.textTracks;
             for (var k = 0; k < hlsjsTracks.length; k++) {
                 if (hlsjsTracks[k].kind === 'subtitles' || hlsjsTracks[k].kind === 'captions') {
-                    hlsjsTracks[k].mode = activeTrack !== null
-                        && hlsjsTracks[k].language === activeTrack.language ? 'showing' : 'hidden';
+                    // NOTE: label here is readable label and is optional (used in the UI so if it is there it has to be different)
+                    var hlsTrackId = hlsjsTracks[k].label ? hlsjsTracks[k].label : hlsjsTracks[k].language;
+                    var vjsTrackId = null;
+                    if (activeTrack !== null) {
+                        vjsTrackId = activeTrack.label ? activeTrack.label : activeTrack.language;
+                    }
+                    hlsjsTracks[k].mode = hlsTrackId === vjsTrackId ? 'showing' : 'hidden';
                 }
             }
         }

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -117,6 +117,33 @@ var registerSourceHandler = function (videojs) {
             tech.trigger('loadedqualitydata', payload);
         }
 
+        function _onAudioTracks() {
+            var hlsAudioTracks = _hls.audioTracks;
+            var playerAudioTracks = tech.audioTracks();
+            if (hlsAudioTracks.length > 1 && playerAudioTracks.length === 0) {
+                // Add Hls.js audio tracks if not added yet
+                for (var i = 0; i < hlsAudioTracks.length; i++) {
+                    playerAudioTracks.addTrack(new videojs.AudioTrack({
+                        id: i,
+                        kind: 'alternative',
+                        label: hlsAudioTracks[i].name || hlsAudioTracks[i].lang,
+                        language: hlsAudioTracks[i].lang,
+                        enabled: i === _hls.audioTrack
+                    }));
+                }
+
+                // Handle audio track change event
+                playerAudioTracks.addEventListener('change', function () {
+                    for (var j = 0; j < playerAudioTracks.length; j++) {
+                        if (playerAudioTracks[j].enabled) {
+                            _hls.audioTrack = j;
+                            break;
+                        }
+                    }
+                });
+            }
+        }
+
         function _startLoad() {
             _hls.startLoad(-1);
             _video.removeEventListener('play', _startLoad);
@@ -151,6 +178,7 @@ var registerSourceHandler = function (videojs) {
 
             _hls.on(Hlsjs.Events.ERROR, function (event, data) { _onError(event, data, tech, _errorCounts); });
             _hls.on(Hlsjs.Events.MANIFEST_PARSED, _onMetaData);
+            _hls.on(Hlsjs.Events.AUDIO_TRACK_LOADED, _onAudioTracks);
             _hls.on(Hlsjs.Events.LEVEL_LOADED, function (event, data) { _duration = data.details.live ? Infinity : data.details.totalduration; });
 
             _hls.attachMedia(_video);

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -144,6 +144,25 @@ var registerSourceHandler = function (videojs) {
             }
         }
 
+        function _updateHlsjsTextTrack() {
+            var playerTextTracks = _player.textTracks();
+            var activeTrack = null;
+            for (var j = 0; j < playerTextTracks.length; j++) {
+                if (playerTextTracks[j].mode === 'showing') {
+                    activeTrack = playerTextTracks[j];
+                    break;
+                }
+            }
+
+            var hlsjsTracks = _video.textTracks;
+            for (var k = 0; k < hlsjsTracks.length; k++) {
+                if (hlsjsTracks[k].kind === 'subtitles' || hlsjsTracks[k].kind === 'captions') {
+                    hlsjsTracks[k].mode = activeTrack !== null
+                        && hlsjsTracks[k].language === activeTrack.language ? 'showing' : 'hidden';
+                }
+            }
+        }
+
         function _startLoad() {
             _hls.startLoad(-1);
             _video.removeEventListener('play', _startLoad);
@@ -172,6 +191,9 @@ var registerSourceHandler = function (videojs) {
                 _video.addEventListener('play', _startLoad);
             }
 
+            // For some reason running this after generating text track list will raise an error inside Hls.js (too early perhaps)
+            _video.addEventListener('play', _updateHlsjsTextTrack);
+
             _hls = new Hlsjs(hlsjsConfig);
 
             _executeHooksFor('beforeinitialize');
@@ -185,8 +207,44 @@ var registerSourceHandler = function (videojs) {
             _hls.loadSource(source.src);
         }
 
+        function _filterTextTracks(textTracks) {
+            var displayableTracks = [];
+
+            // Filter out tracks that is displayable (captions or subtitltes)
+            for (var idx = 0; idx < textTracks.length; idx++) {
+                if (textTracks[idx].kind === 'subtitles' || textTracks[idx].kind === 'captions') {
+                    displayableTracks.push(textTracks[idx]);
+                }
+            }
+
+            return displayableTracks;
+        }
+
+        function _onAddTextTrack() {
+            var displayableTracks = _filterTextTracks(_video.textTracks);
+            var playerTextTracks = _player.textTracks();
+            if (displayableTracks.length > 0 && playerTextTracks.length === 0) {
+                // Add stubs to make the caption switcher shows up
+                // NOTE: Adding the Hls.js text track in will make us have double captions
+                for (var idx = 0; idx < displayableTracks.length; idx++) {
+                    var hlsjsTextTrack = displayableTracks[idx];
+                    _player.addRemoteTextTrack({
+                        label: hlsjsTextTrack.label,
+                        language: hlsjsTextTrack.language,
+                        srclang: hlsjsTextTrack.language
+                    }, false);
+                }
+
+                // Handle UI switching
+                playerTextTracks.addEventListener('change', _updateHlsjsTextTrack);
+            }
+        }
+
         function initialize() {
             _initHlsjs();
+
+            // Handle text tracks
+            _video.textTracks.onaddtrack = _onAddTextTrack;
         }
 
         this.duration = function () {

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -119,7 +119,7 @@ var registerSourceHandler = function (videojs) {
                 tech.trigger('loadedqualitydata', payload);
 
                 // Self-de-register so we don't raise the payload multiple times
-                _video.removeEventListener('play', _notifyVideoQualities);
+                _video.removeEventListener('playing', _notifyVideoQualities);
             }
         }
 
@@ -242,7 +242,7 @@ var registerSourceHandler = function (videojs) {
             _video.addEventListener('play', _updateHlsjsTextTrack);
 
             // _notifyVideoQualities sometimes runs before the quality picker event handler is registered -> no video switcher
-            _video.addEventListener('play', _notifyVideoQualities);
+            _video.addEventListener('playing', _notifyVideoQualities);
 
             _hls = new Hlsjs(hlsjsConfig);
 
@@ -272,7 +272,7 @@ var registerSourceHandler = function (videojs) {
         this.dispose = function () {
             _video.removeEventListener('play', _startLoad);
             _video.removeEventListener('play', _updateHlsjsTextTrack);
-            _video.removeEventListener('play', _notifyVideoQualities);
+            _video.removeEventListener('playing', _notifyVideoQualities);
 
             _player.textTracks().removeEventListener('change', _updateHlsjsTextTrack);
             _player.audioTracks().removeEventListener('change', _updateHlsjsAudioTrack);


### PR DESCRIPTION
- Properly integrate with VideoJS `TextTracks` and `AudioTracks` API to allow the viewer to switch audio stream and subtitle.
- Fix race condition on `videojs-quality-picker` API support:
  - `loadedqualiydata` event sometimes (as in happen with a probability when refresh) is raised before the handlers in the `videojs-quality-picker` is registered.
  - Potential explanation is because in VJS 6 `html5` tech is not created when the plugin is loaded. Thus we need to wait until the video player is `ready` but Hls.js manifest could be parsed before the (async) ready callback is called -> payload missed. 😢 