### PR TITLE
Also match alternative HLS manifest MIME type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Alternative MIME-type `application/vnd.apple.mpegurl` for HLS manifest not matched.
 
 ## [1.0.0] - 2018-08-14
 ### CI

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -356,7 +356,7 @@ var registerSourceHandler = function (videojs) {
 
         html5.registerSourceHandler({
             canHandleSource: function (source) {
-                var hlsTypeRE = /^application\/x-mpegURL$/i;
+                var hlsTypeRE = /^application\/x-mpegURL|application\/vnd\.apple\.mpegurl$/i;
                 var hlsExtRE = /\.m3u8/i;
                 var result;
 


### PR DESCRIPTION
- We forgot about the other MIME type for HLS manifest, which breaks a client use-case.