### PR TITLE
Add support for `videojs-contrib-quality-levels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support for `videojs-contrib-quality-levels` plugin.
 
 ## [1.0.3] - 2018-09-12
 ### Fixed

--- a/example/index-plugin.html
+++ b/example/index-plugin.html
@@ -8,33 +8,37 @@
     <script src="http://vjs.zencdn.net/6.6.3/video.js"></script>
 
     <!-- Brightcove DVRUX plugin -->
-    <!-- <link href="//players.brightcove.net/videojs-live-dvrux/1/videojs-live-dvrux.min.css" rel="stylesheet"> -->
-    <!-- <script src="//players.brightcove.net/videojs-live-dvrux/1/videojs-live-dvrux.min.js"></script> -->
+    <link href="//players.brightcove.net/videojs-live-dvrux/1/videojs-live-dvrux.min.css" rel="stylesheet">
+    <script src="//players.brightcove.net/videojs-live-dvrux/1/videojs-live-dvrux.min.js"></script>
+
+    <!-- Brightcove quality picker -->
+    <link href="//players.brightcove.net/videojs-quality-menu/1/videojs-quality-menu.css" rel="stylesheet">
+    <script src="//players.brightcove.net/videojs-quality-menu/1/videojs-quality-menu.min.js"></script>
 
     <script src="../dist/videojs-hlsjs-plugin.js"></script>
 </head>
 <body>
     <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls autoplay muted>
-        <source src="http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8" type="application/x-mpegURL"/>
+        <source src="https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8" type="application/x-mpegURL"/>
     </video>
 
     <script>
         var options = {
             plugins: {
-              // JSON config added by Brightcove player generator
-              streamrootHls: {
-                hlsjsConfig: {
-                  // Your Hls.js config
+                // JSON config added by Brightcove player generator
+                streamrootHls: {
+                    hlsjsConfig: {
+                        // Your Hls.js config
+                    }
                 },
-              }
+                qualityMenu: {
+                    useResolutionLabels: true
+                }
             }
         };
         var player = videojs('example-video', options);
-
-        // Activate Brightcove's DVRUX plugin
-        // player.ready(function () {
-        //     player.dvrux();
-        // });
+        player.qualityMenu();
+        player.dvrux();
     </script>
 </body>
 </html>

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -93,6 +93,61 @@ var registerSourceHandler = function (videojs) {
             return 0;
         }
 
+        function _relayQualityChange(qualityLevels) {
+            // Determine if it is "Auto" (all tracks enabled)
+            var isAuto = true;
+            for (var i = 0; i < qualityLevels.length; i++) {
+                if (!qualityLevels[i]._enabled) {
+                    isAuto = false;
+                    break;
+                }
+            }
+
+            // Interact with ME
+            if (isAuto) {
+                _hls.currentLevel = -1;
+            } else {
+                // Find ID of highest enabled track
+                var selectedTrack;
+                for (selectedTrack = qualityLevels.length - 1; selectedTrack >= 0; selectedTrack--) {
+                    if (qualityLevels[selectedTrack]._enabled) {
+                        break;
+                    }
+                }
+                _hls.currentLevel = selectedTrack;
+            }
+        }
+
+        function _toggleLevel(level, toggle) {
+            // NOTE: Brightcove switcher works TextTracks-style (enable tracks that it wants to ABR on)
+            if (typeof toggle === 'boolean') {
+                this[level]._enabled = toggle;
+                _relayQualityChange(this);
+            }
+            return this[level]._enabled;
+        }
+
+        function _handleQualityLevels() {
+            if (_metadata) {
+                var qualityLevels = _player.qualityLevels();
+                if (qualityLevels) {
+                    for (var i = 0; i < _metadata.levels.length; i++) {
+                        var details = _metadata.levels[i];
+                        var representation = {
+                            id: i,
+                            width: details.width,
+                            height: details.height,
+                            bandwidth: details.bitrate,
+                            bitrate: details.bitrate,
+                            _enabled: true
+                        };
+                        representation.enabled = _toggleLevel.bind(qualityLevels, i);
+                        qualityLevels.addQualityLevel(representation);
+                    }
+                }
+            }
+        }
+
         function _notifyVideoQualities() {
             if (_metadata) {
                 var cleanTracklist = [];
@@ -231,6 +286,7 @@ var registerSourceHandler = function (videojs) {
         function _onMetaData(event, data) {
             // This could arrive before 'loadedqualitydata' handlers is registered, remember it so we can raise it later
             _metadata = data;
+            _handleQualityLevels();
         }
 
         function _initHlsjs() {


### PR DESCRIPTION
- It is the "quasi-standard" video quality API.
- Used by Brightcove's vanilla video quality switcher.
- It is the one implemented with `videojs-contrib-hls` so any picker targeting that also works with us.