### PR TITLE
Bump bundled Hls.js version to 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Bump bunded `hls.js` version to `0.10.1`.
 
 ## [1.0.5] - 2018-10-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Bump bunded `hls.js` version to `0.10.1`.
+- Bump bunded `hls.js` version to `0.12.2`.
 
 ## [1.0.5] - 2018-10-31
 ### Fixed

--- a/example/index-plugin.html
+++ b/example/index-plugin.html
@@ -20,8 +20,7 @@
 <body>
     <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls autoplay muted>
         <!-- <source src="http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8" type="application/x-mpegURL"/> -->
-        <source src="https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8" type="application/x-mpegURL"/>
-        <!-- <source src="//cdn.theoplayer.com/video/elephants-dream/playlist.m3u8" type="application/x-mpegURL"/> -->
+        <source src="//cdn.theoplayer.com/video/elephants-dream/playlist.m3u8" type="application/x-mpegURL"/>
     </video>
 
     <script>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:lint": "eslint lib/"
   },
   "dependencies": {
-    "hls.js": "^0.8.9"
+    "hls.js": "0.10.1"
   },
   "devDependencies": {
     "ajv": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:lint": "eslint lib/"
   },
   "dependencies": {
-    "hls.js": "0.10.1"
+    "hls.js": "0.12.2"
   },
   "devDependencies": {
     "ajv": "^6.4.0",


### PR DESCRIPTION
There's a [potential bug with streams with timing gaps in `0.8.x` ](https://github.com/video-dev/hls.js/issues/1393) that was fixed in `0.9.x` and might be the one plaguing a client. This PR bump the bundled `hls.js` version to last QA-verified version of `0.12.2`.