### PR TITLE
[no-deploy] Update webpack and its dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "eslint-config-airbnb-base": "12.1.0",
     "eslint-plugin-import": "2.8.0",
     "uglify-js": "2.6.0",
-    "video.js": "^5.20.5",
-    "webpack": "3.8.1",
-    "webpack-dev-server": "2.11.2"
+    "uglifyjs-webpack-plugin": "2.1.1",
+    "webpack": "4.28.3",
+    "webpack-cli": "3.2.1",
+    "webpack-dev-server": "3.1.14"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const { version } = require('./package.json');
 
@@ -39,11 +40,18 @@ module.exports = env => {
       new webpack.LoaderOptionsPlugin({
           minimize: true,
           debug: false,
-      }),
-      new webpack.optimize.UglifyJsPlugin({
-          compress: {
+      })
+    );
+  }
+
+  return {
+    mode: 'production',
+    optimization: {
+      minimizer: [
+        new UglifyJsPlugin({
+          uglifyOptions: {
+            compress: {
               warnings: false,
-              screw_ie8: true,
               conditionals: true,
               unused: true,
               comparisons: true,
@@ -52,17 +60,16 @@ module.exports = env => {
               evaluate: true,
               if_return: true,
               join_vars: true,
-              drop_console: !isDebug,
-          },
-          mangle: true,
-          output: {
-              comments: false,
-          },
-      })
-    );
-  }
-
-  return {
+              drop_console: !isDebug
+            },
+            mangle: true,
+            output: {
+              comments: false
+            }
+          }
+        })
+      ]
+    },
     entry: path.resolve(sourcePath, 'main.js'),
     output: {
       path: distPath,


### PR DESCRIPTION
- Update `webpack-dev-server` to version `>=3.1.11` for a [CVE](https://github.com/streamroot/peer-agent/network/alert/package.json/webpack-dev-server/open). This also necessitate an upgrade of `webpack` itself to `>4`.
- **NOTE:** This will be merged `[no-deploy]` (and after `hls.js` bump)