### PR TITLE
Improve robustness of Hls.js - VJS text track bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Move text track bridge initialization to `playing` where all `TextTrack` are populated to media element by `Hls.js`.
+
+### Fixed
+- Missing `captions` track on switcher because `hls.subtitleTracks` does not contain them.
+- Same-label same-language `caption` and `subtitle` track get switched together.
 
 ## [1.0.6] - 2019-01-08
 ### Changed

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -213,9 +213,13 @@ var registerSourceHandler = function (videojs) {
         }
 
         function _getTextTrackLabel(textTrack) {
+            // NOTE: label here is readable label and is optional (used in the UI so if it is there it should be different)
             var label = textTrack.label ? textTrack.label : textTrack.language;
-            label += textTrack.kind === 'captions' ? ' (cc)' : '';
             return label;
+        }
+
+        function _isSameTextTrack(track1, track2) {
+            return _getTextTrackLabel(track1) === _getTextTrackLabel(track2) && track1.kind === track2.kind;
         }
 
         function _updateSelectedTextTrack() {
@@ -231,13 +235,7 @@ var registerSourceHandler = function (videojs) {
             var hlsjsTracks = _video.textTracks;
             for (var k = 0; k < hlsjsTracks.length; k++) {
                 if (hlsjsTracks[k].kind === 'subtitles' || hlsjsTracks[k].kind === 'captions') {
-                    // NOTE: label here is readable label and is optional (used in the UI so if it is there it has to be different)
-                    var hlsTrackId = _getTextTrackLabel(hlsjsTracks[k]);
-                    var vjsTrackId = null;
-                    if (activeTrack !== null) {
-                        vjsTrackId = activeTrack.label ? activeTrack.label : activeTrack.language;
-                    }
-                    hlsjsTracks[k].mode = hlsTrackId === vjsTrackId ? 'showing' : 'disabled';
+                    hlsjsTracks[k].mode = activeTrack && _isSameTextTrack(hlsjsTracks[k], activeTrack) ? 'showing' : 'disabled';
                 }
             }
         }
@@ -278,6 +276,7 @@ var registerSourceHandler = function (videojs) {
                 for (var idx = 0; idx < displayableTracks.length; idx++) {
                     var hlsjsTextTrack = displayableTracks[idx];
                     _player.addRemoteTextTrack({
+                        kind: hlsjsTextTrack.kind,
                         label: _getTextTrackLabel(hlsjsTextTrack),
                         language: hlsjsTextTrack.language,
                         srclang: hlsjsTextTrack.language

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -231,7 +231,7 @@ var registerSourceHandler = function (videojs) {
                     if (activeTrack !== null) {
                         vjsTrackId = activeTrack.label ? activeTrack.label : activeTrack.language;
                     }
-                    hlsjsTracks[k].mode = hlsTrackId === vjsTrackId ? 'showing' : 'hidden';
+                    hlsjsTracks[k].mode = hlsTrackId === vjsTrackId ? 'showing' : 'disabled';
                 }
             }
         }

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -182,7 +182,7 @@ var registerSourceHandler = function (videojs) {
             }
         }
 
-        function _updateHlsjsAudioTrack() {
+        function _updateSelectedAudioTrack() {
             var playerAudioTracks = tech.audioTracks();
             for (var j = 0; j < playerAudioTracks.length; j++) {
                 if (playerAudioTracks[j].enabled) {
@@ -208,11 +208,17 @@ var registerSourceHandler = function (videojs) {
                 }
 
                 // Handle audio track change event
-                playerAudioTracks.addEventListener('change', _updateHlsjsAudioTrack);
+                playerAudioTracks.addEventListener('change', _updateSelectedAudioTrack);
             }
         }
 
-        function _updateHlsjsTextTrack() {
+        function _getTextTrackLabel(textTrack) {
+            var label = textTrack.label ? textTrack.label : textTrack.language;
+            label += textTrack.kind === 'captions' ? ' (cc)' : '';
+            return label;
+        }
+
+        function _updateSelectedTextTrack() {
             var playerTextTracks = _player.textTracks();
             var activeTrack = null;
             for (var j = 0; j < playerTextTracks.length; j++) {
@@ -226,7 +232,7 @@ var registerSourceHandler = function (videojs) {
             for (var k = 0; k < hlsjsTracks.length; k++) {
                 if (hlsjsTracks[k].kind === 'subtitles' || hlsjsTracks[k].kind === 'captions') {
                     // NOTE: label here is readable label and is optional (used in the UI so if it is there it has to be different)
-                    var hlsTrackId = hlsjsTracks[k].label ? hlsjsTracks[k].label : hlsjsTracks[k].language;
+                    var hlsTrackId = _getTextTrackLabel(hlsjsTracks[k]);
                     var vjsTrackId = null;
                     if (activeTrack !== null) {
                         vjsTrackId = activeTrack.label ? activeTrack.label : activeTrack.language;
@@ -250,12 +256,12 @@ var registerSourceHandler = function (videojs) {
             return result;
         }
 
-        function _filterTextTracks(textTracks) {
+        function _filterDisplayableTextTracks(textTracks) {
             var displayableTracks = [];
 
             // Filter out tracks that is displayable (captions or subtitltes)
             for (var idx = 0; idx < textTracks.length; idx++) {
-                if (textTracks[idx].type.toLowerCase() === 'subtitles' || textTracks[idx].type.toLowerCase() === 'captions') {
+                if (textTracks[idx].kind === 'subtitles' || textTracks[idx].kind === 'captions') {
                     displayableTracks.push(textTracks[idx]);
                 }
             }
@@ -263,8 +269,8 @@ var registerSourceHandler = function (videojs) {
             return displayableTracks;
         }
 
-        function _onAddTextTrack() {
-            var displayableTracks = _filterTextTracks(_hls.subtitleTracks);
+        function _updateTextTrackList() {
+            var displayableTracks = _filterDisplayableTextTracks(_video.textTracks);
             var playerTextTracks = _player.textTracks();
             if (displayableTracks.length > 0 && playerTextTracks.length === 0) {
                 // Add stubs to make the caption switcher shows up
@@ -272,14 +278,15 @@ var registerSourceHandler = function (videojs) {
                 for (var idx = 0; idx < displayableTracks.length; idx++) {
                     var hlsjsTextTrack = displayableTracks[idx];
                     _player.addRemoteTextTrack({
-                        label: hlsjsTextTrack.name,
-                        language: hlsjsTextTrack.lang,
-                        srclang: hlsjsTextTrack.lang
+                        label: _getTextTrackLabel(hlsjsTextTrack),
+                        language: hlsjsTextTrack.language,
+                        srclang: hlsjsTextTrack.language
                     }, false);
                 }
 
                 // Handle UI switching
-                playerTextTracks.addEventListener('change', _updateHlsjsTextTrack);
+                _updateSelectedTextTrack();
+                playerTextTracks.addEventListener('change', _updateSelectedTextTrack);
             }
         }
 
@@ -304,7 +311,7 @@ var registerSourceHandler = function (videojs) {
             }
 
             // For some reason running this after generating text track list will raise an error inside Hls.js (too early perhaps)
-            _video.addEventListener('play', _updateHlsjsTextTrack);
+            _video.addEventListener('playing', _updateTextTrackList);
 
             // _notifyVideoQualities sometimes runs before the quality picker event handler is registered -> no video switcher
             _video.addEventListener('playing', _notifyVideoQualities);
@@ -327,9 +334,6 @@ var registerSourceHandler = function (videojs) {
                 _dvrDuration = data.details.totalduration;
                 _duration = _isLive ? Infinity : data.details.totalduration;
             });
-
-            // Handle text tracks
-            _hls.on(Hlsjs.Events.SUBTITLE_TRACKS_UPDATED, _onAddTextTrack);
 
             _hls.attachMedia(_video);
             _hls.loadSource(source.src);
@@ -359,11 +363,11 @@ var registerSourceHandler = function (videojs) {
         // See comment for `initialize` method.
         this.dispose = function () {
             _video.removeEventListener('play', _startLoad);
-            _video.removeEventListener('play', _updateHlsjsTextTrack);
+            _video.removeEventListener('playing', _updateTextTrackList);
             _video.removeEventListener('playing', _notifyVideoQualities);
 
-            _player.textTracks().removeEventListener('change', _updateHlsjsTextTrack);
-            _player.audioTracks().removeEventListener('change', _updateHlsjsAudioTrack);
+            _player.textTracks().removeEventListener('change', _updateSelectedTextTrack);
+            _player.audioTracks().removeEventListener('change', _updateSelectedAudioTrack);
 
             _hls.destroy();
         };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = env => {
   }
 
   const isDev = nodeEnv === 'development';
-  const isDebug = env && env.debug;
+  const isDebug = env && env.debug || isDev;
 
   const plugins = [
       new webpack.DefinePlugin({


### PR DESCRIPTION
**Observations:**
- `hls.subtitleTracks` apparently only have `subtitle` tracks and no `captions`.
- `metadata` and `caption` tracks is not available when `Hlsjs.Events.SUBTITLE_TRACKS_UPDATED` is emitted.
- Fix an issue where same-language same-label `caption` and `subtitle` track gets switched at the same time.