### PR TITLE
Handle post-play added text tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- `TextTracks` added after video starts playing is not updated properly.
 
 ## [1.0.7] - 2019-01-17
 ### Changed

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -17,6 +17,8 @@ var registerSourceHandler = function (videojs) {
         var _hlsjsConfig = null;
         var _player = videojs(tech.options_.playerId);
 
+        var _uiTextTrackHandled = false;
+
         function _executeHooksFor(type) {
             if (hooks[type] === undefined) {
                 return;
@@ -295,7 +297,10 @@ var registerSourceHandler = function (videojs) {
 
             // Handle UI switching
             _updateSelectedTextTrack();
-            playerTextTracks.addEventListener('change', _updateSelectedTextTrack);
+            if (!_uiTextTrackHandled) {
+                playerTextTracks.addEventListener('change', _updateSelectedTextTrack);
+                _uiTextTrackHandled = true;
+            }
         }
 
         function _onMetaData(event, data) {
@@ -373,6 +378,7 @@ var registerSourceHandler = function (videojs) {
             _video.removeEventListener('playing', _notifyVideoQualities);
 
             _player.textTracks().removeEventListener('change', _updateSelectedTextTrack);
+            _uiTextTrackHandled = false;
             _player.audioTracks().removeEventListener('change', _updateSelectedAudioTrack);
 
             _hls.destroy();

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -270,10 +270,19 @@ var registerSourceHandler = function (videojs) {
         function _updateTextTrackList() {
             var displayableTracks = _filterDisplayableTextTracks(_video.textTracks);
             var playerTextTracks = _player.textTracks();
-            if (displayableTracks.length > 0 && playerTextTracks.length === 0) {
-                // Add stubs to make the caption switcher shows up
-                // NOTE: Adding the Hls.js text track in will make us have double captions
-                for (var idx = 0; idx < displayableTracks.length; idx++) {
+
+            // Add stubs to make the caption switcher shows up
+            // NOTE: Adding the Hls.js text track in will make us have double captions
+            for (var idx = 0; idx < displayableTracks.length; idx++) {
+                var isAdded = false;
+                for (var jdx = 0; jdx < playerTextTracks.length; jdx++) {
+                    if (_isSameTextTrack(displayableTracks[idx], playerTextTracks[jdx])) {
+                        isAdded = true;
+                        break;
+                    }
+                }
+
+                if (!isAdded) {
                     var hlsjsTextTrack = displayableTracks[idx];
                     _player.addRemoteTextTrack({
                         kind: hlsjsTextTrack.kind,
@@ -282,11 +291,11 @@ var registerSourceHandler = function (videojs) {
                         srclang: hlsjsTextTrack.language
                     }, false);
                 }
-
-                // Handle UI switching
-                _updateSelectedTextTrack();
-                playerTextTracks.addEventListener('change', _updateSelectedTextTrack);
             }
+
+            // Handle UI switching
+            _updateSelectedTextTrack();
+            playerTextTracks.addEventListener('change', _updateSelectedTextTrack);
         }
 
         function _onMetaData(event, data) {
@@ -308,9 +317,6 @@ var registerSourceHandler = function (videojs) {
             if (_hlsjsConfig.autoStartLoad === false) {
                 _video.addEventListener('play', _startLoad);
             }
-
-            // For some reason running this after generating text track list will raise an error inside Hls.js (too early perhaps)
-            _video.addEventListener('playing', _updateTextTrackList);
 
             // _notifyVideoQualities sometimes runs before the quality picker event handler is registered -> no video switcher
             _video.addEventListener('playing', _notifyVideoQualities);
@@ -335,6 +341,7 @@ var registerSourceHandler = function (videojs) {
             });
 
             _hls.attachMedia(_video);
+            _video.textTracks.addEventListener('addtrack', _updateTextTrackList);
             _hls.loadSource(source.src);
         }
 
@@ -362,7 +369,7 @@ var registerSourceHandler = function (videojs) {
         // See comment for `initialize` method.
         this.dispose = function () {
             _video.removeEventListener('play', _startLoad);
-            _video.removeEventListener('playing', _updateTextTrackList);
+            _video.textTracks.removeEventListener('addtrack', _updateTextTrackList);
             _video.removeEventListener('playing', _notifyVideoQualities);
 
             _player.textTracks().removeEventListener('change', _updateSelectedTextTrack);


### PR DESCRIPTION
- In some streams the CC text track could be added by `Hls.js` after it is `playing`. This PR aims to properly handles that use case.