### PR TITLE
Add ability to override hard-coded caption positioning in Hls.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Capability to override Hls.js `caption` position.
 
 ## [1.0.8] - 2019-01-24
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,4 +97,7 @@ You can remove the hook by:
 videojs.Html5Hlsjs.removeHook('beforeinitialize', callback);
 ```
 
+### Caption configurations
+In `hls.js` if caption positioning information is not provided in `WebVTT` it will be hard coded into a certain location on-screen. We provide a custom option to allow users to override property of the caption's cues: https://developer.mozilla.org/en-US/docs/Web/API/VTTCue
+
 You can add as many `beforeinitialize` hooks as necessary by calling `videojs.Html5Hlsjs.addHook` several times.

--- a/example/index-plugin.html
+++ b/example/index-plugin.html
@@ -30,7 +30,13 @@
                 streamrootHls: {
                     hlsjsConfig: {
                         // Your Hls.js config
-                    }
+                    },
+                    // captionConfig: {
+                    //     line: -1,
+                    //     align: 'center',
+                    //     position: 50,
+                    //     size: 40,
+                    // }
                 },
                 qualityMenu: {
                     useResolutionLabels: true

--- a/example/index.html
+++ b/example/index.html
@@ -11,8 +11,7 @@
 </head>
 <body>
     <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls autoplay muted>
-        <source src="http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8" type="application/x-mpegURL"/>
-        <!-- <source src="//cdn.theoplayer.com/video/elephants-dream/playlist.m3u8" type="application/x-mpegURL"/> -->
+        <source src="//cdn.theoplayer.com/video/elephants-dream/playlist.m3u8" type="application/x-mpegURL"/>
         <!-- <source src="//bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8" type="application/x-mpegURL"/> -->
     </video>
 

--- a/example/index.html
+++ b/example/index.html
@@ -20,7 +20,13 @@
             html5: {
                 hlsjsConfig: {
                   // Put your hls.js config here
-                }
+                },
+                // captionConfig: {
+                //     line: -1,
+                //     align: 'center',
+                //     position: 50,
+                //     size: 40,
+                // }
             }
         };
         var player = videojs('example-video', options);

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -309,6 +309,39 @@ var registerSourceHandler = function (videojs) {
             _handleQualityLevels();
         }
 
+        function _createCueHandler(captionConfig) {
+            return {
+                newCue: function (track, startTime, endTime, captionScreen) {
+                    var row;
+                    var cue;
+                    var text;
+                    var VTTCue = window.VTTCue || window.TextTrackCue;
+
+                    for (var r = 0; r < captionScreen.rows.length; r++) {
+                        row = captionScreen.rows[r];
+                        text = '';
+                        if (!row.isEmpty()) {
+                            for (var c = 0; c < row.chars.length; c++) {
+                                text += row.chars[c].uchar;
+                            }
+                            cue = new VTTCue(startTime, endTime, text.trim());
+
+                            // NOTE: typeof null === 'object'
+                            if (captionConfig != null && typeof captionConfig === 'object') {
+                                // Copy client overridden property into the cue object
+                                var configKeys = Object.keys(captionConfig);
+                                for (var k = 0; k < configKeys.length; k++) {
+                                    cue[configKeys[k]] = captionConfig[configKeys[k]];
+                                }
+                            }
+                            track.addCue(cue);
+                            if (endTime === startTime) track.addCue(new VTTCue(endTime + 5, ''));
+                        }
+                    }
+                }
+            };
+        }
+
         function _initHlsjs() {
             var hlsjsConfigRef = tech.options_.hlsjsConfig;
             // NOTE: Hls.js will write to the reference thus change the object for later streams
@@ -316,6 +349,10 @@ var registerSourceHandler = function (videojs) {
 
             if (['', 'auto'].indexOf(_video.preload) === -1 && !_video.autoplay && _hlsjsConfig.autoStartLoad === undefined) {
                 _hlsjsConfig.autoStartLoad = false;
+            }
+
+            if (tech.options_.captionConfig) {
+                _hlsjsConfig.cueHandler = _createCueHandler(tech.options_.captionConfig);
             }
 
             // If the user explicitely sets autoStartLoad to false, we're not going to enter the if block above, that's why we have a separate if block here to set the 'play' listener
@@ -499,6 +536,10 @@ function streamrootHlsjsConfigHandler(options) {
 
     if (!player.options_.html5.hlsjsConfig) {
         player.options_.html5.hlsjsConfig = options.hlsjsConfig;
+    }
+
+    if (!player.options_.html5.captionConfig) {
+        player.options_.html5.captionConfig = options.captionConfig;
     }
 }
 


### PR DESCRIPTION
- A client migrating to us reported that Hls.js does not put the caption in the place he expected. Unfortunately it is not possible to alter caption position using CSS nor the client can add positioning information into his WebVTT files.
- To support this client, we add the ability to programmatically override caption positioning.