### PR TITLE
Fix config not applied to source handler in certain initialization workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Plugin-style configuration not applied when plugin is activated before `tech` is attached.
 
 ## [1.0.9] - 2019-02-19
 ### Added

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -343,7 +343,7 @@ var registerSourceHandler = function (videojs) {
         }
 
         function _initHlsjs() {
-            var hlsjsConfigRef = tech.options_.hlsjsConfig;
+            var hlsjsConfigRef = _player.srOptions_ && _player.srOptions_.hlsjsConfig || tech.options_.hlsjsConfig;
             // NOTE: Hls.js will write to the reference thus change the object for later streams
             _hlsjsConfig = hlsjsConfigRef ? _oneLevelObjClone(hlsjsConfigRef) : {};
 
@@ -351,8 +351,9 @@ var registerSourceHandler = function (videojs) {
                 _hlsjsConfig.autoStartLoad = false;
             }
 
-            if (tech.options_.captionConfig) {
-                _hlsjsConfig.cueHandler = _createCueHandler(tech.options_.captionConfig);
+            var captionConfig = _player.srOptions_ && _player.srOptions_.captionConfig || tech.options_.captionConfig;
+            if (captionConfig) {
+                _hlsjsConfig.cueHandler = _createCueHandler(captionConfig);
             }
 
             // If the user explicitely sets autoStartLoad to false, we're not going to enter the if block above, that's why we have a separate if block here to set the 'play' listener
@@ -530,16 +531,17 @@ function streamrootHlsjsConfigHandler(options) {
         return;
     }
 
-    if (!player.options_.html5) {
-        player.options_.html5 = {};
+
+    if (!player.srOptions_) {
+        player.srOptions_ = {};
     }
 
-    if (!player.options_.html5.hlsjsConfig) {
-        player.options_.html5.hlsjsConfig = options.hlsjsConfig;
+    if (!player.srOptions_.hlsjsConfig) {
+        player.srOptions_.hlsjsConfig = options.hlsjsConfig;
     }
 
-    if (!player.options_.html5.captionConfig) {
-        player.options_.html5.captionConfig = options.captionConfig;
+    if (!player.srOptions_.captionConfig) {
+        player.srOptions_.captionConfig = options.captionConfig;
     }
 }
 


### PR DESCRIPTION
**Problem:** 
- When using the plugin with `Brightcove's VideoCloud`, the configuration injected via JSON on the `Player Editor` is not applied to the source handler on runtime. It doesn't happen if we use the player with an out-of-OVP manifest URL.

**Diagnostics:**
- The config are passed correctly but by the time the config plugin is activated the `tech` is not created.
- The player then rewrite the `tech` object we added with the real tech dropping all injected configurations.
- The source handler that created after the `tech` see no config -> 💣 

**Major changes:**
- Attach injected config to an object on the player itself to avoid unexpected re-writes.