### PR TITLE
Fix library bundling and update bundled Hls.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Bump bunded `hls.js` version to `0.12.2`.
+- Bump bunded `hls.js` version to `0.12.4`.
 
 ### Fixed
 - Missing module exports after `webpack` update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Bump bunded `hls.js` version to `0.12.2`.
+
+### Fixed
+- Missing module exports after `webpack` update.
 
 ## [1.0.10] - 2019-02-26
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:lint": "eslint lib/"
   },
   "dependencies": {
-    "hls.js": "0.12.2"
+    "hls.js": "0.12.4"
   },
   "devDependencies": {
     "ajv": "^6.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,6 +72,8 @@ module.exports = env => {
     },
     entry: path.resolve(sourcePath, 'main.js'),
     output: {
+      library: 'hlsSourceHandler',
+      libraryTarget: 'umd',
       path: distPath,
       filename: 'videojs-hlsjs-plugin.js'
     },


### PR DESCRIPTION
- Update `Hls.js` from `0.12.2` to `0.12.4` which fixed a critical bug in IE.
- Fix missing export after `webpack 4` update.