### PR TITLE
Emulate custom `loadedmetadata` behavior of default HLS plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Emulation of `videojs-contrib-hls` emitting `loadedmetadata` after parsing the manifest for plugin compatability.
+- Emulation of `videojs-contrib-hls` emitting `loadedmetadata` after loading first segment for plugin compatability.
 
 ## [1.0.12] - 2019-05-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Emulation of `videojs-contrib-hls` emitting `loadedmetadata` after parsing the manifest for plugin compatability.
 
 ## [1.0.12] - 2019-05-10
 ### Fixed

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -382,9 +382,9 @@ var registerSourceHandler = function (videojs) {
                 _dvrDuration = data.details.totalduration;
                 _duration = _isLive ? Infinity : data.details.totalduration;
             });
-            _hls.once(Hlsjs.Events.MANIFEST_PARSED, function () {
+            _hls.once(Hlsjs.Events.FRAG_LOADED, function () {
                 // Emit custom 'loadedmetadata' event for parity with `videojs-contrib-hls`
-                // Ref: https://github.com/videojs/videojs-contrib-hls/blob/master/src/playlist-loader.js#L402
+                // Ref: https://github.com/videojs/videojs-contrib-hls#loadedmetadata
                 tech.trigger('loadedmetadata');
             });
 

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -382,6 +382,11 @@ var registerSourceHandler = function (videojs) {
                 _dvrDuration = data.details.totalduration;
                 _duration = _isLive ? Infinity : data.details.totalduration;
             });
+            _hls.once(Hlsjs.Events.MANIFEST_PARSED, function () {
+                // Emit custom 'loadedmetadata' event for parity with `videojs-contrib-hls`
+                // Ref: https://github.com/videojs/videojs-contrib-hls/blob/master/src/playlist-loader.js#L402
+                tech.trigger('loadedmetadata');
+            });
 
             _hls.attachMedia(_video);
             _video.textTracks.addEventListener('addtrack', _updateTextTrackList);


### PR DESCRIPTION
A client has an `autoplay` mechanism relying on a custom behavior of the default HLS playback plugin. This PR attempts to emulate that behavior to improve our compatibility with such use cases.