### PR TITLE
Fix `videojs-hls-quality-selector` plugin not showing up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Supports `videojs-hls-quality-selector` plugin.
 
 ## [1.0.14] - 2020-06-08
 ### Changed

--- a/example/index-brightcove.html
+++ b/example/index-brightcove.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
 
     <!-- video.js -->
-    <link href="http://vjs.zencdn.net/6.6.3/video-js.css" rel="stylesheet">
-    <script src="http://vjs.zencdn.net/6.6.3/video.js"></script>
+    <link href="http://vjs.zencdn.net/7.8.2/video-js.css" rel="stylesheet">
+    <script src="http://vjs.zencdn.net/7.8.2/video.js"></script>
 
     <!-- Brightcove DVRUX plugin -->
     <link href="//players.brightcove.net/videojs-live-dvrux/1/videojs-live-dvrux.min.css" rel="stylesheet">

--- a/example/index-hlsqualityselector.html
+++ b/example/index-hlsqualityselector.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+
+    <!-- video.js -->
+    <link href="http://vjs.zencdn.net/7.8.2/video-js.css" rel="stylesheet">
+    <script src="http://vjs.zencdn.net/7.8.2/video.js"></script>
+
+    <!-- -->
+    <script src="https://cdn.jsdelivr.net/npm/videojs-contrib-quality-levels@2.0.9/dist/videojs-contrib-quality-levels.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/videojs-hls-quality-selector@1.1.1/dist/videojs-hls-quality-selector.min.js"></script>
+
+    <script src="../dist/videojs-hlsjs-plugin.js"></script>
+</head>
+<body>
+    <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls autoplay muted>
+        <!-- <source src="http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8" type="application/x-mpegURL"/> -->
+        <source src="//cdn.theoplayer.com/video/elephants-dream/playlist.m3u8" type="application/x-mpegURL"/>
+    </video>
+
+    <script>
+        var options = {
+            html5: {
+                hlsjsConfig: {
+                  // Put your hls.js config here
+                },
+                // captionConfig: {
+                //     line: -1,
+                //     align: 'center',
+                //     position: 50,
+                //     size: 40,
+                // }
+            }
+        };
+        var player = videojs('example-video', options);
+        player.hlsQualitySelector();
+    </script>
+</body>
+</html>

--- a/example/index-hlsqualityselector.html
+++ b/example/index-hlsqualityselector.html
@@ -7,7 +7,7 @@
     <link href="http://vjs.zencdn.net/7.8.2/video-js.css" rel="stylesheet">
     <script src="http://vjs.zencdn.net/7.8.2/video.js"></script>
 
-    <!-- -->
+    <!-- videojs-hls-quality-selector -->
     <script src="https://cdn.jsdelivr.net/npm/videojs-contrib-quality-levels@2.0.9/dist/videojs-contrib-quality-levels.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/videojs-hls-quality-selector@1.1.1/dist/videojs-hls-quality-selector.min.js"></script>
 

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -16,6 +16,10 @@ var registerSourceHandler = function (videojs) {
         var _edgeMargin = null;
         var _hlsjsConfig = null;
         var _player = videojs(tech.options_.playerId);
+        var qualityLevels = _player.qualityLevels && _player.qualityLevels();
+        if (qualityLevels) {
+            tech.hls = {};
+        }
 
         var _uiTextTrackHandled = false;
 
@@ -95,7 +99,7 @@ var registerSourceHandler = function (videojs) {
             return 0;
         }
 
-        function _relayQualityChange(qualityLevels) {
+        function _relayQualityChange() {
             // Determine if it is "Auto" (all tracks enabled)
             var isAuto = true;
             for (var i = 0; i < qualityLevels.length; i++) {
@@ -122,31 +126,47 @@ var registerSourceHandler = function (videojs) {
 
         function _toggleLevel(level, toggle) {
             // NOTE: Brightcove switcher works TextTracks-style (enable tracks that it wants to ABR on)
-            if (typeof toggle === 'boolean') {
-                this[level]._enabled = toggle;
-                _relayQualityChange(this);
+            if (qualityLevels) {
+                if (typeof toggle === 'boolean') {
+                    qualityLevels[level]._enabled = toggle;
+                    _relayQualityChange();
+                }
+                return qualityLevels[level]._enabled;
             }
-            return this[level]._enabled;
+            return false;
         }
 
         function _handleQualityLevels() {
             if (_metadata) {
-                var qualityLevels = _player.qualityLevels && _player.qualityLevels();
+                qualityLevels = _player.qualityLevels && _player.qualityLevels();
                 if (qualityLevels) {
+                    tech.hls = {};
                     for (var i = 0; i < _metadata.levels.length; i++) {
                         var details = _metadata.levels[i];
+                        var name = 'hlsjs-' + i;
                         var representation = {
-                            id: i,
+                            id: name,
+                            label: name,
                             width: details.width,
                             height: details.height,
                             bandwidth: details.bitrate,
                             bitrate: details.bitrate,
-                            _enabled: true
+                            _enabled: false
                         };
-                        representation.enabled = _toggleLevel.bind(qualityLevels, i);
+                        representation.enabled = _toggleLevel.bind(this, i);
                         qualityLevels.addQualityLevel(representation);
                     }
                 }
+            }
+        }
+
+        function _syncQualityLevels(event, data) {
+            if (qualityLevels) {
+                qualityLevels.selectedIndex_ = data.level;
+                qualityLevels.trigger({
+                    selectedIndex: data.level,
+                    type: 'change'
+                });
             }
         }
 
@@ -387,6 +407,7 @@ var registerSourceHandler = function (videojs) {
                 // Ref: https://github.com/videojs/videojs-contrib-hls#loadedmetadata
                 tech.trigger('loadedmetadata');
             });
+            _hls.on(Hlsjs.Events.LEVEL_SWITCHED, _syncQualityLevels);
 
             _hls.attachMedia(_video);
             _video.textTracks.addEventListener('addtrack', _updateTextTrackList);

--- a/lib/videojs-hlsjs-plugin.js
+++ b/lib/videojs-hlsjs-plugin.js
@@ -17,7 +17,9 @@ var registerSourceHandler = function (videojs) {
         var _hlsjsConfig = null;
         var _player = videojs(tech.options_.playerId);
         var qualityLevels = _player.qualityLevels && _player.qualityLevels();
-        if (qualityLevels) {
+
+        // The `videojs-hls-quality-selector` plugin only activates when tech.hls is defined.
+        if (qualityLevels && _player.hlsQualitySelector) {
             tech.hls = {};
         }
 


### PR DESCRIPTION
**Related issue:** https://github.com/chrisboustead/videojs-hls-quality-selector/issues/27

**Major changes:**
- Add a dummy object to bypass an unnecessary check in the `videojs-hls-quality-selector` plugin.